### PR TITLE
feat: ignore some common non js or ts file types

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -35,7 +35,7 @@ const options = {
 	parser: argv.parser,
 	print: false,
 	verbose: argv.verbosity,
-	ignorePattern: ['*.json', '*.css', '*.txt', '*.png', '*.jpg', "*.ttf"]
+	extensions: 'js,jsx,ts,tsx'
 };
 
 if (argv.verbosity > 0) {

--- a/src/bin.js
+++ b/src/bin.js
@@ -35,6 +35,7 @@ const options = {
 	parser: argv.parser,
 	print: false,
 	verbose: argv.verbosity,
+	ignorePattern: ['*.json', '*.css', '*.txt', '*.png', '*.jpg', "*.ttf"]
 };
 
 if (argv.verbosity > 0) {

--- a/src/bin.js
+++ b/src/bin.js
@@ -35,7 +35,7 @@ const options = {
 	parser: argv.parser,
 	print: false,
 	verbose: argv.verbosity,
-	extensions: 'js,jsx,ts,tsx'
+	extensions: 'js,jsx,ts,tsx,mjs'
 };
 
 if (argv.verbosity > 0) {


### PR DESCRIPTION
**Problem:**

When using this tool on an application that has non ts/js files in the same directory as js and ts files it logs errors for unsupported files.

**Solution:**

Specify the file extensions to code mod (js, jsx, ts, tsx) explcitly
